### PR TITLE
Introduce ftdetect

### DIFF
--- a/ftdetect/modulemap.vim
+++ b/ftdetect/modulemap.vim
@@ -1,0 +1,6 @@
+" vim ftdetect file
+" Language: C++ module map
+" Maintainer: Saleem Abdulrasool <compnerd@compnerd.org>
+" Author: Kohki Miki <giginet.net@gmail.com>
+
+au BufRead,BufNewFile *.modulemap set ft=modulemap syntax=modulemap


### PR DESCRIPTION
Hi! Currently, `*.modulemap` could not be detected as C++ module map.
So this syntax not affect automatically.

This PR make to set filetype for `*.modulemap` automatically.